### PR TITLE
Add build plan markdown documents

### DIFF
--- a/docs/build-plan/README.md
+++ b/docs/build-plan/README.md
@@ -1,0 +1,15 @@
+# Pocket Philosopher Build Plan
+
+This directory contains the comprehensive build plan derived from the requirements in the `build_specs` folder. Each document focuses on a major workstream needed to deliver the Pocket Philosopher application.
+
+## Documents
+
+- [Project Foundations & Environment](project-foundations-and-environment.md)
+- [Data & Backend Infrastructure](data-and-backend-infrastructure.md)
+- [AI & Knowledge System](ai-and-knowledge-system.md)
+- [Frontend Architecture & User Experience](frontend-architecture-and-user-experience.md)
+- [Analytics, Observability & Security](analytics-observability-and-security.md)
+- [Testing & Quality Assurance](testing-and-quality-assurance.md)
+- [Deployment & Operations](deployment-and-operations.md)
+
+Each document provides detailed tasks and instructions to guide implementation for its respective area.

--- a/docs/build-plan/ai-and-knowledge-system.md
+++ b/docs/build-plan/ai-and-knowledge-system.md
@@ -1,0 +1,26 @@
+# AI & Knowledge System
+
+## 1. Provider Abstraction Layer
+- Implement a unified AI service interface supporting `complete`, `stream`, `embed`, and `getHealthStatus` methods.
+- Build provider clients for OpenAI, Anthropic, Together, and Ollama.
+- Introduce health caching and failover logic driven by configuration priorities.
+
+## 2. Retrieval-Augmented Generation (RAG)
+- Implement hybrid retrieval utilities combining vector and keyword search.
+- Integrate pgvector, semantic reranking, and caching mechanisms.
+- Support persona and tradition filtering alongside citation validation pipelines.
+
+## 3. Persona & Prompt System
+- Define persona metadata including voice, virtues, prompts, and constraints.
+- Assemble system prompt templates and user context enrichment flows.
+- Enforce output formatting with citations and suggested micro-actions.
+
+## 4. Conversation Workflow & Persistence
+- Implement `/api/marcus` streaming flow with cache checks and context enrichment.
+- Manage Supabase persistence for chat transcripts and relevant telemetry events.
+- Handle SSE/ReadableStream responses to provide real-time updates.
+
+## 5. Corpus Management Tools
+- Build ingestion scripts for philosophy texts and metadata updates.
+- Add monitoring endpoints and administrative actions for corpus status tracking.
+- Automate embedding generation and maintain progress visibility.

--- a/docs/build-plan/analytics-observability-and-security.md
+++ b/docs/build-plan/analytics-observability-and-security.md
@@ -1,0 +1,16 @@
+# Analytics, Observability & Security
+
+## 1. Telemetry Integration
+- Instrument PostHog analytics across frontend and backend surfaces.
+- Capture AI metrics, usage events, and performance indicators.
+- Implement structured logging and health diagnostics endpoints.
+
+## 2. Security & Privacy
+- Enforce Content Security Policy (CSP) and secure headers for all routes.
+- Implement data sanitization, input validation, and RLS policy adherence.
+- Redact sensitive AI prompts and ensure secrets are stored securely.
+
+## 3. Accessibility & Inclusivity
+- Audit keyboard navigation, semantic markup, and ARIA labels.
+- Validate color contrast and ensure inclusive, shame-free messaging.
+- Incorporate accessibility checks into development workflows.

--- a/docs/build-plan/data-and-backend-infrastructure.md
+++ b/docs/build-plan/data-and-backend-infrastructure.md
@@ -1,0 +1,27 @@
+# Data & Backend Infrastructure
+
+## 1. Supabase Provisioning
+- Create the Supabase project and configure environments (local, staging, production).
+- Run schema migrations from `database/schema.sql` and any additional RAG-related migrations.
+- Enable Row Level Security (RLS) and configure authentication providers.
+- Set up backups, monitoring, and observability hooks per specifications.
+
+## 2. Database Automations
+- Implement Supabase functions and triggers, including `calculate_daily_progress` and `recalculate_progress_on_habit_log_change`.
+- Add indexes and policies to support performance and security requirements.
+- Document automation logic and establish processes for future migrations.
+
+## 3. Seed Data
+- Populate habit templates, persona metadata, and initial philosophy corpus records.
+- Create ingestion utilities or scripts to support ongoing dataset updates.
+- Ensure seed scripts are idempotent and usable across environments.
+
+## 4. API Middleware & Utilities
+- Develop `withAuthAndRateLimit` middleware for consistent auth and throttling.
+- Build Supabase client factories, Zod validation schemas, sanitization helpers, and standardized response formatters.
+- Integrate logging and metrics hooks to support observability.
+
+## 5. API Routes Implementation
+- Implement API endpoints for `auth`, `profile`, `habits`, `daily-progress`, `progress`, `reflections`, `marcus`, `ai/*`, `health`, and `debug`.
+- Apply documented behaviors, rate limits, and payload contracts across endpoints.
+- Ensure robust error handling and response messaging.

--- a/docs/build-plan/deployment-and-operations.md
+++ b/docs/build-plan/deployment-and-operations.md
@@ -1,0 +1,16 @@
+# Deployment & Operations
+
+## 1. Local & Staging Environments
+- Provide Docker Compose setup for Next.js, Supabase, and optional Redis/Ollama.
+- Ensure configuration parity between local, staging, and production environments.
+- Document developer onboarding steps and environment variable requirements.
+
+## 2. Production Rollout
+- Prepare deployment guides covering environment provisioning, secrets management, schema migrations, and seed scripts.
+- Establish observability dashboards and on-call runbooks.
+- Define rollout checklists and communication plans for releases.
+
+## 3. Post-Launch Iterations
+- Integrate feedback loops and analytics insights into product planning.
+- Manage feature flags via `app_settings` to support progressive delivery.
+- Outline roadmap for AI provider expansions and edge function adoption.

--- a/docs/build-plan/frontend-architecture-and-user-experience.md
+++ b/docs/build-plan/frontend-architecture-and-user-experience.md
@@ -1,0 +1,28 @@
+# Frontend Architecture & User Experience
+
+## 1. App Shell & Routing
+- Scaffold the App Router layout with public and authenticated segments.
+- Implement navigation shell, theme provider, analytics hooks, and offline-aware wrappers.
+- Ensure routing aligns with documented flow and accessibility requirements.
+
+## 2. State Management
+- Rebuild Zustand stores for auth, daily progress, habits, streaming, and UI preferences.
+- Integrate TanStack Query for server state management and caching.
+- Implement local storage hydration strategies for offline drafts and resiliency.
+
+## 3. Core Pages & Flows
+- `(dashboard)/today`: morning intention, habit logging, analytics tiles, daily quote.
+- `(dashboard)/habits`: CRUD UI, scheduling controls, reminder settings.
+- `(dashboard)/reflections`: guided journaling with mood sliders and persona cues.
+- `(dashboard)/coaches` (`/marcus`): chat interface, persona switcher, citation display, streaming status UI.
+- Profile, settings, onboarding, help/support pages aligned with experience specs.
+
+## 4. UI Components & Styling
+- Assemble shadcn/ui component library and design system tokens.
+- Implement responsive layouts, accessibility semantics, and aria attributes.
+- Add Framer Motion interactions and micro-animations per experience guidelines.
+
+## 5. Offline & PWA Features
+- Configure Workbox service worker with defined caching strategies.
+- Implement install prompts and offline storage synchronization flows.
+- Validate behavior across desktop and mobile scenarios.

--- a/docs/build-plan/project-foundations-and-environment.md
+++ b/docs/build-plan/project-foundations-and-environment.md
@@ -1,0 +1,17 @@
+# Project Foundations & Environment
+
+## 1. Review Specifications & Define Scope
+- Consolidate all requirements from the System Overview, Backend & Data, Frontend, and AI specifications.
+- Produce a master scope document enumerating features, constraints, and success criteria.
+- Identify cross-team dependencies and sequencing of subsystems.
+
+## 2. Environment Setup
+- Scaffold a Next.js 14 App Router project with TypeScript.
+- Install and configure Tailwind CSS, shadcn/ui, Framer Motion, Zustand, and TanStack Query.
+- Establish shared linting, formatting, and testing baselines (ESLint, Prettier, Jest, Playwright).
+- Implement environment variable validation (`lib/env-validation.ts`) and prepare a `.env.local` template including Supabase, AI provider, analytics, and email credentials.
+
+## 3. Repository Structure
+- Recreate the documented directory layout (e.g., `app/`, `lib/`, `database/`, `public/`, `scripts/`).
+- Include placeholder files or README notes where needed to guide future implementation.
+- Ensure structure aligns with spec references to ease collaboration across teams.

--- a/docs/build-plan/testing-and-quality-assurance.md
+++ b/docs/build-plan/testing-and-quality-assurance.md
@@ -1,0 +1,16 @@
+# Testing & Quality Assurance
+
+## 1. Automated Testing
+- Implement Jest unit and integration tests for stores, hooks, API routes, and AI modules.
+- Configure Playwright end-to-end flows covering auth, onboarding, habit logging, reflections, coach chat, and offline scenarios.
+- Establish testing data fixtures and utilities for repeatable scenarios.
+
+## 2. Evaluation Harness
+- Build AI prompt regression suite validating persona adherence, citation accuracy, and output formatting.
+- Integrate evaluation harness into the CI pipeline for automated guardrails.
+- Monitor evaluation results and create remediation workflows.
+
+## 3. CI/CD
+- Configure pipelines covering linting, type checking, unit tests, and Playwright suites.
+- Prepare deployment scripts for Vercel/Fly.io with environment promotion checks.
+- Establish notification channels for build failures and regressions.


### PR DESCRIPTION
## Summary
- add documentation directory for the comprehensive build plan derived from the specs
- break the plan into focused markdown files covering each major workstream
- provide index README linking to each document for easy navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d40e4f70b8832693b45cc4a5351b7d