### PR TITLE
Add task breakdowns for build plan components

### DIFF
--- a/docs/build-plan/tasks/README.md
+++ b/docs/build-plan/tasks/README.md
@@ -1,0 +1,39 @@
+# Pocket Philosopher Build Tasks Execution Guide
+
+This guide outlines a recommended execution sequence for the task plans derived from the build-plan specifications. Follow each step in order; tasks labeled with **[P]** in the component plans can be run in parallel once their prerequisites are met.
+
+## Step-by-Step Execution
+1. **Project Foundations & Environment**  
+   - Follow the tasks in `project-foundations-and-environment/tasks.md` to confirm scope, bootstrap the repository, and finalize baseline tooling.  
+   - Completion of Phase 2 unlocks parallelizable environment hardening tasks for other teams.
+2. **Data & Backend Infrastructure (Phase 1 prerequisites only)**  
+   - Execute Supabase provisioning tasks in `data-and-backend-infrastructure/tasks.md` to ensure database availability for downstream work.  
+   - Coordinate with the foundations team for environment variables and access controls.
+3. **Frontend Architecture & User Experience (Phase 1 & 2)**  
+   - Implement the application shell, routing, and state infrastructure per `frontend-architecture-and-user-experience/tasks.md`.  
+   - Begin [P] tasks (analytics hooks, local storage utilities) once foundational routing is stable.
+4. **AI & Knowledge System (Phase 1 & 2)**  
+   - Stand up the provider abstraction and retrieval stack using `ai-and-knowledge-system/tasks.md`.  
+   - These efforts can run alongside frontend state work after Supabase schemas and environment variables are ready.
+5. **Data & Backend Infrastructure (Phases 2–4)**  
+   - Implement database automations, middleware, and API routes.  
+   - Coordinate with AI and frontend teams to validate contracts and streaming behaviors.
+6. **Frontend Architecture & User Experience (Phases 3–4)**  
+   - Build core dashboard flows, component libraries, and PWA enhancements, leveraging backend and AI endpoints as they stabilize.
+7. **AI & Knowledge System (Phases 3–5)**  
+   - Finalize persona prompts, conversation workflows, corpus ingestion, and telemetry integration.
+8. **Analytics, Observability & Security**  
+   - Apply the controls outlined in `analytics-observability-and-security/tasks.md`, leveraging instrumentation hooks established earlier.  
+   - Run [P] accessibility and security tasks once primary flows exist in staging.
+9. **Deployment & Operations**  
+   - Use `deployment-and-operations/tasks.md` to prepare Docker tooling, rollout guides, runbooks, and post-launch governance.
+10. **Testing & Quality Assurance**  
+    - Implement the automated testing, AI evaluation harness, and CI/CD workflows described in `testing-and-quality-assurance/tasks.md`.  
+    - Integrate with deployment processes to gate releases.
+11. **Final Verification**  
+    - Ensure all component tasks (including parallel [P] items) are complete, documentation is updated, and staging/production environments are in sync before declaring the rebuild feature-complete.
+
+## Parallelization Tips
+- Treat **[P]** tasks as candidates for separate work streams once the preceding numbered items in their phase are finished.
+- Use weekly syncs between frontend, backend, and AI leads to coordinate shared dependencies and adjust sequencing as needed.
+- Maintain a shared Kanban board mirroring these steps to track ownership and progress.

--- a/docs/build-plan/tasks/ai-and-knowledge-system/tasks.md
+++ b/docs/build-plan/tasks/ai-and-knowledge-system/tasks.md
@@ -1,0 +1,26 @@
+# AI & Knowledge System — Task Plan
+
+## Phase 1: Provider Abstraction Layer
+1. Design the unified AI service interface covering completion, streaming, embedding, and health checks with TypeScript contracts.
+2. Implement provider clients for OpenAI, Anthropic, Together, and Ollama, including configuration-driven model selection.
+3. Add provider health caching, failover thresholds, and telemetry hooks to enable dynamic degradation logic. [P]
+
+## Phase 2: Retrieval-Augmented Generation Stack
+1. Stand up hybrid retrieval utilities leveraging pgvector search, keyword filtering, and semantic reranking.
+2. Implement caching strategies (in-memory and optional Redis) for retrieval results, prompt payloads, and provider health. [P]
+3. Build citation validation and formatting pipelines to ensure referenced texts meet quality criteria. [P]
+
+## Phase 3: Persona & Prompt Architecture
+1. Define persona metadata (voice, virtues, prompts, constraints) and register them within the AI service.
+2. Create system prompt templates and user-context assembly functions merging habits, reflections, and virtue focus.
+3. Enforce output formatting rules that include acknowledgements, insights, micro-actions, and citations across personas.
+
+## Phase 4: Conversation Workflow & Persistence
+1. Implement the `/api/marcus` streaming flow, including cache lookups, context enrichment, and SSE/ReadableStream responses.
+2. Persist conversations, messages, citations, and provider metadata in Supabase, ensuring ordering and retention policies. [P]
+3. Emit telemetry events capturing latency, tokens, retrieval counts, and provider usage for observability dashboards. [P]
+
+## Phase 5: Corpus Management Toolkit
+1. Build ingestion scripts to normalize philosophy texts, chunk content, and generate embeddings for storage.
+2. Implement administrative endpoints for ingestion status, forcing re-ingestion, and monitoring corpus health.
+3. Document operations playbooks for maintaining and expanding the philosophy corpus across traditions.

--- a/docs/build-plan/tasks/analytics-observability-and-security/tasks.md
+++ b/docs/build-plan/tasks/analytics-observability-and-security/tasks.md
@@ -1,0 +1,16 @@
+# Analytics, Observability & Security — Task Plan
+
+## Phase 1: Telemetry Framework
+1. Integrate PostHog instrumentation across frontend routes and key backend actions, documenting event schemas and naming conventions.
+2. Capture AI-specific metrics (latency, token usage, retrieval count) and pipe them into monitoring dashboards. [P]
+3. Implement structured logging helpers and enrich `/api/health` diagnostics with dependency checks. [P]
+
+## Phase 2: Security & Privacy Controls
+1. Define and enforce Content Security Policy (CSP) and secure headers for Next.js pages and API routes.
+2. Audit and implement input validation, sanitization, and RLS policies across the stack, closing any identified gaps.
+3. Establish secrets management practices and prompt-redaction utilities for AI logs, ensuring compliance with privacy standards. [P]
+
+## Phase 3: Accessibility & Inclusivity Assurance
+1. Perform accessibility audits covering keyboard navigation, semantic structure, and ARIA labeling across core flows.
+2. Validate color contrast ratios and inclusive language guidelines, updating design tokens or content where needed. [P]
+3. Incorporate automated accessibility checks into CI pipelines and document remediation workflows. [P]

--- a/docs/build-plan/tasks/data-and-backend-infrastructure/tasks.md
+++ b/docs/build-plan/tasks/data-and-backend-infrastructure/tasks.md
@@ -1,0 +1,22 @@
+# Data & Backend Infrastructure — Task Plan
+
+## Phase 1: Supabase Provisioning & Governance
+1. Stand up Supabase projects for local, staging, and production; document connection details and environment parity requirements.
+2. Apply schema migrations (`database/schema.sql` and RAG-related files) and verify table structures, indexes, and extensions.
+3. Enable authentication providers, configure RLS policies, and establish automated backups plus monitoring hooks. [P]
+
+## Phase 2: Database Automations & Seed Data
+1. Implement and validate stored procedures, triggers, and scheduled tasks (e.g., `calculate_daily_progress`, `recalculate_progress_on_habit_log_change`).
+2. Define index and policy optimization backlog to ensure performance across habit, reflection, and analytics queries. [P]
+3. Build idempotent seed scripts for habit templates, persona metadata, and philosophy corpus starters; run against all environments.
+
+## Phase 3: API Platform Foundation
+1. Develop `withAuthAndRateLimit` middleware, Supabase client factories, validation schemas, sanitization helpers, and shared response formatters.
+2. Integrate structured logging and metrics instrumentation consistent with observability guidelines. [P]
+3. Configure error handling conventions, including retry headers for rate-limit breaches and standardized error payloads. [P]
+
+## Phase 4: API Route Implementation
+1. Implement `auth`, `profile`, and `daily-progress` routes covering login flows, profile management, and morning intention updates.
+2. Deliver `habits`, `progress`, and `reflections` routes with action-based payloads, optimistic updates, and analytics aggregation.
+3. Build `marcus` and `ai/*` endpoints coordinating with the AI orchestration layer, including streaming support and admin tooling.
+4. Finalize `health` and `debug` routes with comprehensive diagnostics and secure admin access pathways. [P]

--- a/docs/build-plan/tasks/deployment-and-operations/tasks.md
+++ b/docs/build-plan/tasks/deployment-and-operations/tasks.md
@@ -1,0 +1,16 @@
+# Deployment & Operations — Task Plan
+
+## Phase 1: Environment Parity & Tooling
+1. Author Docker Compose configurations for Next.js, Supabase, and optional Redis/Ollama services to support local development.
+2. Document onboarding steps for engineers, including environment variable requirements, database setup, and verification checks.
+3. Establish configuration baselines ensuring parity between local, staging, and production environments (e.g., feature flags, secrets management). [P]
+
+## Phase 2: Production Rollout Preparation
+1. Draft deployment guides covering infrastructure provisioning, schema migrations, seed scripts, and backup strategies.
+2. Build observability dashboards and on-call runbooks detailing alert sources, escalation paths, and mitigation steps. [P]
+3. Define release checklists, communication plans, and rollback procedures for staged and emergency deployments. [P]
+
+## Phase 3: Post-Launch Continuous Improvement
+1. Integrate analytics-driven feedback loops into product planning cadences, highlighting key metrics and qualitative inputs.
+2. Implement feature flag governance via `app_settings`, including naming conventions and rollout playbooks. [P]
+3. Outline roadmap for AI provider expansion, Supabase edge functions, and infrastructure scaling milestones.

--- a/docs/build-plan/tasks/frontend-architecture-and-user-experience/tasks.md
+++ b/docs/build-plan/tasks/frontend-architecture-and-user-experience/tasks.md
@@ -1,0 +1,23 @@
+# Frontend Architecture & User Experience — Task Plan
+
+## Phase 1: Shell & Routing Foundation
+1. Implement the App Router public and authenticated layouts, including providers (QueryClientProvider, ThemeProvider, Toast) and offline-aware wrappers.
+2. Build global navigation (top bar, sidebar) with accessibility instrumentation and route guards tied to the auth store.
+3. Configure analytics hooks and page-level metadata scaffolding to align with observability and SEO requirements. [P]
+
+## Phase 2: State Management & Data Access
+1. Reconstruct Zustand stores for auth, daily progress, habits, UI, and streaming with TypeScript typings and Immer helpers.
+2. Wire TanStack Query hooks for Supabase-backed data fetching, including caching, refetch intervals, and optimistic update patterns.
+3. Implement local storage hydration and offline draft persistence utilities shared across stores. [P]
+
+## Phase 3: Core Experience Flows
+1. Build the `(dashboard)/today` experience: morning intention form, habit quick actions, Return Score tiles, and inspirational quote modules.
+2. Deliver `(dashboard)/habits` with CRUD modals, scheduling controls, reminder settings, and drag-and-drop ordering.
+3. Implement `(dashboard)/reflections` guided journaling, mood sliders, persona cues, and timeline views.
+4. Assemble `(dashboard)/coaches` (`/marcus`) streaming chat with persona switcher, citation list, and typing indicators.
+5. Complete supporting routes (onboarding, profile, settings, help) with consistent layout components and responsive design. [P]
+
+## Phase 4: UI Components, Styling, and PWA Enhancements
+1. Curate shadcn/ui component library extensions, Tailwind theme tokens, and design documentation.
+2. Add Framer Motion animations and focus-visible states to critical interactions while preserving performance budgets. [P]
+3. Configure Workbox service worker, install prompts, and offline synchronization flows; validate behavior on desktop and mobile.

--- a/docs/build-plan/tasks/project-foundations-and-environment/tasks.md
+++ b/docs/build-plan/tasks/project-foundations-and-environment/tasks.md
@@ -1,0 +1,17 @@
+# Project Foundations & Environment — Task Plan
+
+## Phase 1: Specification Alignment
+1. Inventory all build specifications (system overview, frontend, backend & data, AI) and extract feature, constraint, and success-criteria highlights into a shared outline.
+2. Facilitate a cross-discipline review to confirm scope boundaries, identify open questions, and record dependencies or blockers.
+3. Publish the master scope document in the project knowledge base and circulate sign-off requests from engineering, product, and design leads.
+
+## Phase 2: Environment Bootstrap
+1. Initialize the Next.js 14 + TypeScript repository with the documented directory layout and base configuration files.
+2. Install Tailwind CSS, shadcn/ui, Framer Motion, Zustand, TanStack Query, and supporting lint/test tooling; capture the package manifest and configuration notes in the repo README.
+3. Configure shared linting and formatting rules (ESLint, Prettier) alongside Jest and Playwright baselines. [P]
+4. Scaffold the environment variable validation module (`lib/env-validation.ts`) and supply an example `.env.local` template populated with placeholders for Supabase, AI providers, analytics, and email credentials. [P]
+
+## Phase 3: Repository Structure Hardening
+1. Recreate required top-level directories (`app/`, `lib/`, `database/`, `public/`, `scripts/`) and seed each with placeholder docs describing intended responsibilities.
+2. Verify references between specs and repository paths, updating documentation if discrepancies appear.
+3. Run a workspace health check (lint, type check, unit smoke test) to ensure the baseline environment is reproducible for all contributors.

--- a/docs/build-plan/tasks/testing-and-quality-assurance/tasks.md
+++ b/docs/build-plan/tasks/testing-and-quality-assurance/tasks.md
@@ -1,0 +1,16 @@
+# Testing & Quality Assurance — Task Plan
+
+## Phase 1: Automated Testing Foundations
+1. Configure Jest for unit and integration coverage across stores, hooks, API routes, and AI modules, including module mocks and shared fixtures.
+2. Stand up Playwright end-to-end suites covering auth, onboarding, habit logging, reflections, coach chat, and offline scenarios; define test data management strategy.
+3. Establish reusable testing utilities (factories, Supabase seeders, mock AI providers) to streamline scenario creation. [P]
+
+## Phase 2: AI Evaluation Harness
+1. Build regression harness validating persona adherence, citation accuracy, and output formatting for AI responses.
+2. Integrate evaluation runs into CI with thresholds that gate merges; document remediation procedures for failures. [P]
+3. Monitor evaluation metrics over time and maintain a backlog of prompt or retrieval adjustments informed by results. [P]
+
+## Phase 3: CI/CD Integration
+1. Configure CI pipelines to run linting, type checks, unit tests, Playwright suites, and AI evaluations on pull requests and main branch builds.
+2. Prepare deployment automation scripts for Vercel/Fly.io with environment promotion checks and rollback hooks. [P]
+3. Establish notification channels (Slack/email) for build failures, flaky test reports, and evaluation regressions; document escalation flows. [P]


### PR DESCRIPTION
## Summary
- add task plans for each build-plan specification outlining phased work and parallelizable items
- document execution sequencing and parallelization guidance in a dedicated tasks README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d42590c1dc8326ae19d9ac4f58b574