### PR TITLE
feat: add AI provider abstraction layer

### DIFF
--- a/docs/build-plan/tasks/ai-and-knowledge-system/provider-abstraction.md
+++ b/docs/build-plan/tasks/ai-and-knowledge-system/provider-abstraction.md
@@ -1,0 +1,25 @@
+# Provider Abstraction Layer
+
+## Overview
+The provider registry introduces a unified contract for chat and embedding workloads so that Pocket Philosopher can orchestrate multiple AI vendors behind a single interface. Providers implement shared request/response types from `lib/ai/types.ts` and are registered with priorities to enable graceful failover. Analytics events are emitted when provider health changes or when downstream requests fail, allowing us to monitor reliability regressions without touching the call sites.
+
+## Architecture Decisions
+- **Shared contracts** – `lib/ai/types.ts` now defines message, streaming, embedding, and health interfaces used by all vendors and the registry. Each provider returns the same `AIChatStreamResult` shape (async generator plus deferred usage) so orchestrators can remain vendor-agnostic.
+- **Provider clients** – Implementations for OpenAI, Anthropic, Together, and Ollama live in `lib/ai/providers/`. They lean on the Fetch API, `AbortController`, and SSE/NDJSON parsing to deliver streamed responses. Clients guard against missing environment configuration and raise descriptive errors when keys or URLs are absent. Embeddings are implemented for OpenAI and Together; Anthropic and Ollama expose TODO placeholders until first-party APIs are available.
+- **Registry orchestration** – `lib/ai/provider-registry.ts` maintains ordered provider lists for chat and embeddings. Providers are sorted by priority (ascending) and weight (descending) so the system will select the highest-priority healthy vendor, fall back to degraded options, and finally use the first registered provider if every check fails.
+- **Health caching** – Health checks are cached for 30 seconds to avoid spamming vendor APIs. Cached entries are invalidated automatically after the TTL and refreshed on demand. Analytics events (`ai_provider_health_changed`) fire whenever a provider transitions between health states, enabling alerting when a vendor drops from healthy to degraded/unavailable.
+- **Failure instrumentation** – The registry exposes `recordProviderFailure` which callers can use when an invocation fails. Events are captured as `ai_request_failed` with provider metadata so we can analyze incident frequency.
+
+## Configuration Requirements
+- **OpenAI** – Requires `OPENAI_API_KEY`. Both chat and embeddings are supported. Health checks hit the `/v1/models` endpoint.
+- **Anthropic** – Requires `ANTHROPIC_API_KEY`. Chat streaming is available via the Messages API. Embeddings are not yet supported; attempts will throw with a TODO message. Health checks query `/v1/models`.
+- **Together** – Requires `TOGETHER_API_KEY`. Chat and embeddings mirror OpenAI’s payload contract. Health checks query `/v1/models`.
+- **Ollama** – Requires `OLLAMA_URL` pointing at the Ollama daemon. Chat streaming consumes NDJSON responses from `/api/chat`. Embeddings are a TODO placeholder until upstream support lands. Health checks call `/api/tags` on the configured host.
+
+Ensure the relevant environment variables are set before enabling a provider; missing configuration is treated as an unavailable health state so the registry will skip that provider until it is configured.
+
+## Outstanding TODOs
+- Replace the Ollama embedding placeholder once the upstream API exposes vectors.
+- Monitor Anthropic’s roadmap for native embeddings and update the client when available.
+- Improve token accounting once vendor usage semantics stabilize (e.g., unify prompt/completion token naming across providers).
+- Consider persisting provider health snapshots if we need historical uptime reporting beyond the in-memory cache.

--- a/lib/ai/provider-registry.ts
+++ b/lib/ai/provider-registry.ts
@@ -1,0 +1,234 @@
+import type {
+  AIChatProvider,
+  AIEmbeddingProvider,
+  AIProviderHealth,
+  AIProviderStatus,
+} from "@/lib/ai/types";
+import { serverAnalytics } from "@/lib/analytics/server";
+import {
+  checkAnthropicHealth,
+  createAnthropicChatStream,
+} from "@/lib/ai/providers/anthropic";
+import {
+  checkOpenAIHealth,
+  createOpenAIChatStream,
+  createOpenAIEmbedding,
+} from "@/lib/ai/providers/openai";
+import {
+  checkTogetherHealth,
+  createTogetherChatStream,
+  createTogetherEmbedding,
+} from "@/lib/ai/providers/together";
+import { checkOllamaHealth, createOllamaChatStream } from "@/lib/ai/providers/ollama";
+
+const HEALTH_TTL_MS = 30_000;
+const DISTINCT_ID = "ai-provider-registry";
+
+type CachedHealth = {
+  value: AIProviderHealth;
+  expiresAt: number;
+};
+
+type ProviderWithHealth<T extends { id: string }> = T & {
+  checkHealth: (signal?: AbortSignal) => Promise<AIProviderHealth>;
+};
+
+const chatProviders: AIChatProvider[] = [];
+const embeddingProviders: AIEmbeddingProvider[] = [];
+const healthCache = new Map<string, CachedHealth>();
+const lastKnownStatus = new Map<string, AIProviderStatus | undefined>();
+
+function orderProviders<T extends { priority: number; weight?: number }>(providers: T[]): T[] {
+  return [...providers].sort((a, b) => {
+    if (a.priority !== b.priority) {
+      return a.priority - b.priority;
+    }
+    const weightA = typeof a.weight === "number" && a.weight > 0 ? a.weight : 1;
+    const weightB = typeof b.weight === "number" && b.weight > 0 ? b.weight : 1;
+    return weightB - weightA;
+  });
+}
+
+async function evaluateHealth<T extends ProviderWithHealth<{ id: string }>>(
+  provider: T,
+  signal?: AbortSignal,
+): Promise<AIProviderHealth> {
+  const now = Date.now();
+  const cached = healthCache.get(provider.id);
+  if (cached && cached.expiresAt > now) {
+    return cached.value;
+  }
+
+  let result: AIProviderHealth;
+  try {
+    result = await provider.checkHealth(signal);
+  } catch (error) {
+    result = {
+      providerId: provider.id,
+      status: "unavailable",
+      error: {
+        message: error instanceof Error ? error.message : "Provider health check failed",
+      },
+      checkedAt: Date.now(),
+    } satisfies AIProviderHealth;
+  }
+
+  if (result.providerId !== provider.id) {
+    result = { ...result, providerId: provider.id } satisfies AIProviderHealth;
+  }
+
+  healthCache.set(provider.id, { value: result, expiresAt: now + HEALTH_TTL_MS });
+
+  const previousStatus = lastKnownStatus.get(provider.id);
+  lastKnownStatus.set(provider.id, result.status);
+  if (previousStatus && previousStatus !== result.status) {
+    serverAnalytics.capture({
+      event: "ai_provider_health_changed",
+      distinctId: DISTINCT_ID,
+      properties: {
+        providerId: provider.id,
+        previousStatus,
+        currentStatus: result.status,
+        latencyMs: result.latencyMs,
+        error: result.error?.message,
+      },
+    });
+  }
+
+  return result;
+}
+
+async function selectProvider<T extends ProviderWithHealth<{ id: string; priority: number; weight?: number }>>(
+  providers: T[],
+  signal?: AbortSignal,
+): Promise<T | null> {
+  if (providers.length === 0) {
+    return null;
+  }
+
+  const ordered = orderProviders(providers);
+  let degradedCandidate: T | null = null;
+  let fallback: T | null = null;
+
+  for (const provider of ordered) {
+    const health = await evaluateHealth(provider, signal);
+    if (health.status === "healthy") {
+      return provider;
+    }
+    if (health.status === "degraded" && !degradedCandidate) {
+      degradedCandidate = provider;
+    }
+    if (!fallback) {
+      fallback = provider;
+    }
+  }
+
+  return degradedCandidate ?? fallback;
+}
+
+export function registerChatProvider(provider: AIChatProvider): void {
+  const exists = chatProviders.some((item) => item.id === provider.id);
+  if (!exists) {
+    chatProviders.push(provider);
+  }
+}
+
+export function registerEmbeddingProvider(provider: AIEmbeddingProvider): void {
+  const exists = embeddingProviders.some((item) => item.id === provider.id);
+  if (!exists) {
+    embeddingProviders.push(provider);
+  }
+}
+
+export async function getActiveChatProvider(signal?: AbortSignal): Promise<AIChatProvider | null> {
+  return selectProvider(chatProviders, signal);
+}
+
+export async function getActiveEmbeddingProvider(signal?: AbortSignal): Promise<AIEmbeddingProvider | null> {
+  return selectProvider(embeddingProviders, signal);
+}
+
+export async function getProviderHealth(providerId: string, signal?: AbortSignal): Promise<AIProviderHealth | null> {
+  const provider = chatProviders.find((item) => item.id === providerId) ??
+    embeddingProviders.find((item) => item.id === providerId);
+  if (!provider) {
+    return null;
+  }
+
+  return evaluateHealth(provider, signal);
+}
+
+export function recordProviderFailure(
+  providerId: string,
+  error: unknown,
+  properties?: Record<string, unknown>,
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  serverAnalytics.capture({
+    event: "ai_request_failed",
+    distinctId: DISTINCT_ID,
+    properties: {
+      providerId,
+      message,
+      ...properties,
+    },
+  });
+}
+
+function bootstrap(): void {
+  registerChatProvider({
+    id: "openai",
+    displayName: "OpenAI",
+    priority: 1,
+    weight: 2,
+    createChatStream: createOpenAIChatStream,
+    checkHealth: checkOpenAIHealth,
+  });
+
+  registerChatProvider({
+    id: "anthropic",
+    displayName: "Anthropic",
+    priority: 2,
+    weight: 1,
+    createChatStream: createAnthropicChatStream,
+    checkHealth: checkAnthropicHealth,
+  });
+
+  registerChatProvider({
+    id: "together",
+    displayName: "Together AI",
+    priority: 3,
+    weight: 1,
+    createChatStream: createTogetherChatStream,
+    checkHealth: checkTogetherHealth,
+  });
+
+  registerChatProvider({
+    id: "ollama",
+    displayName: "Ollama",
+    priority: 4,
+    weight: 1,
+    createChatStream: createOllamaChatStream,
+    checkHealth: checkOllamaHealth,
+  });
+
+  registerEmbeddingProvider({
+    id: "openai",
+    displayName: "OpenAI",
+    priority: 1,
+    weight: 2,
+    createEmbedding: createOpenAIEmbedding,
+    checkHealth: checkOpenAIHealth,
+  });
+
+  registerEmbeddingProvider({
+    id: "together",
+    displayName: "Together AI",
+    priority: 2,
+    weight: 1,
+    createEmbedding: createTogetherEmbedding,
+    checkHealth: checkTogetherHealth,
+  });
+}
+
+bootstrap();

--- a/lib/ai/providers/anthropic.ts
+++ b/lib/ai/providers/anthropic.ts
@@ -1,0 +1,259 @@
+import type {
+  AIChatStreamRequest,
+  AIChatStreamResult,
+  AIChatUsage,
+  AIEmbeddingRequest,
+  AIEmbeddingResponse,
+  AIProviderHealth,
+} from "@/lib/ai/types";
+import { env } from "@/lib/env-validation";
+
+const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_MODELS_URL = "https://api.anthropic.com/v1/models";
+const ANTHROPIC_VERSION = "2023-06-01";
+
+export class AnthropicConfigurationError extends Error {
+  constructor() {
+    super("ANTHROPIC_API_KEY is not configured. Update your environment before requesting a response.");
+    this.name = "AnthropicConfigurationError";
+  }
+}
+
+type AnthropicMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+type AnthropicStreamEvent =
+  | {
+      type: "content_block_delta";
+      delta?: { type?: string; text?: string };
+    }
+  | {
+      type: "message_delta";
+      usage?: { input_tokens?: number; output_tokens?: number };
+    }
+  | { type: "message_stop" }
+  | { type: "error"; error?: { message?: string } };
+
+function convertMessages(options: AIChatStreamRequest): {
+  system?: string;
+  messages: AnthropicMessage[];
+} {
+  const systemMessages = options.messages
+    .filter((message) => message.role === "system")
+    .map((message) => message.content.trim())
+    .filter(Boolean);
+
+  const conversation = options.messages
+    .filter((message) => message.role !== "system")
+    .map((message) => ({
+      role: message.role === "assistant" ? "assistant" : "user",
+      content: message.content,
+    } satisfies AnthropicMessage));
+
+  return {
+    system: systemMessages.length > 0 ? systemMessages.join("\n\n") : undefined,
+    messages: conversation,
+  };
+}
+
+function toAnthropicUsage(event?: { input_tokens?: number; output_tokens?: number } | null): AIChatUsage | undefined {
+  if (!event) return undefined;
+  const promptTokens = event.input_tokens;
+  const completionTokens = event.output_tokens;
+  const totalTokens =
+    typeof promptTokens === "number" || typeof completionTokens === "number"
+      ? (promptTokens ?? 0) + (completionTokens ?? 0)
+      : undefined;
+
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens,
+  } satisfies AIChatUsage;
+}
+
+export async function createAnthropicChatStream(options: AIChatStreamRequest): Promise<AIChatStreamResult> {
+  if (!env.ANTHROPIC_API_KEY) {
+    throw new AnthropicConfigurationError();
+  }
+
+  const { system, messages } = convertMessages(options);
+  const controller = new AbortController();
+  if (options.signal) {
+    options.signal.addEventListener("abort", () => controller.abort(options.signal?.reason));
+  }
+
+  const response = await fetch(ANTHROPIC_MESSAGES_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": env.ANTHROPIC_API_KEY,
+      "anthropic-version": ANTHROPIC_VERSION,
+    },
+    body: JSON.stringify({
+      model: options.model,
+      messages,
+      system,
+      temperature: options.temperature,
+      max_tokens: options.maxOutputTokens ?? 1024,
+      top_p: options.topP,
+      stream: true,
+      metadata: options.metadata,
+    }),
+    signal: controller.signal,
+  });
+
+  if (!response.ok || !response.body) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(`Anthropic request failed with status ${response.status}: ${detail}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let resolveUsage: (usage: AIChatUsage | undefined) => void = () => undefined;
+  let rejectUsage: (error: unknown) => void = () => undefined;
+  const usagePromise = new Promise<AIChatUsage | undefined>((resolve, reject) => {
+    resolveUsage = resolve;
+    rejectUsage = reject;
+  });
+
+  const stream = (async function* anthropicStream() {
+    let buffer = "";
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const segments = buffer.split("\n\n");
+        buffer = segments.pop() ?? "";
+        for (const segment of segments) {
+          const lines = segment.split("\n");
+          let eventName: string | null = null;
+          let dataPayload = "";
+          for (const line of lines) {
+            if (line.startsWith("event:")) {
+              eventName = line.slice(6).trim();
+            } else if (line.startsWith("data:")) {
+              dataPayload += line.slice(5).trim();
+            }
+          }
+
+          if (!dataPayload || dataPayload === "[DONE]") {
+            if (dataPayload === "[DONE]") {
+              resolveUsage(undefined);
+            }
+            continue;
+          }
+
+          let parsed: AnthropicStreamEvent;
+          try {
+            parsed = JSON.parse(dataPayload) as AnthropicStreamEvent;
+          } catch (error) {
+            console.warn("Failed to parse Anthropic stream payload", error);
+            continue;
+          }
+
+          const type = eventName ?? parsed.type;
+
+          if (type === "content_block_delta") {
+            const text = parsed.delta?.text;
+            if (typeof text === "string" && text.length > 0) {
+              yield text;
+            }
+          } else if (type === "message_delta") {
+            const usage = toAnthropicUsage(parsed.usage);
+            if (usage) {
+              resolveUsage(usage);
+            }
+          } else if (type === "error") {
+            const error = new Error(parsed.error?.message ?? "Anthropic streaming error");
+            rejectUsage(error);
+            throw error;
+          }
+        }
+      }
+
+      resolveUsage(undefined);
+    } catch (error) {
+      rejectUsage(error);
+      throw error;
+    } finally {
+      await reader.cancel().catch(() => undefined);
+    }
+  })();
+
+  return {
+    stream,
+    usage: () => usagePromise,
+  } satisfies AIChatStreamResult;
+}
+
+export async function createAnthropicEmbedding(
+  _request: AIEmbeddingRequest,
+): Promise<AIEmbeddingResponse> {
+  throw new Error("Anthropic embeddings are not available. Track upstream support before enabling.");
+}
+
+export async function checkAnthropicHealth(signal?: AbortSignal): Promise<AIProviderHealth> {
+  const checkedAt = Date.now();
+
+  if (!env.ANTHROPIC_API_KEY) {
+    return {
+      providerId: "anthropic",
+      status: "unavailable",
+      error: {
+        message: "ANTHROPIC_API_KEY is not configured",
+        code: "missing_api_key",
+      },
+      checkedAt,
+    } satisfies AIProviderHealth;
+  }
+
+  const start = Date.now();
+  try {
+    const response = await fetch(ANTHROPIC_MODELS_URL, {
+      headers: {
+        "x-api-key": env.ANTHROPIC_API_KEY,
+        "anthropic-version": ANTHROPIC_VERSION,
+      },
+      signal,
+    });
+    const latencyMs = Date.now() - start;
+
+    if (!response.ok) {
+      return {
+        providerId: "anthropic",
+        status: "degraded",
+        latencyMs,
+        error: {
+          message: `Anthropic health check failed with status ${response.status}`,
+          code: String(response.status),
+        },
+        checkedAt,
+      } satisfies AIProviderHealth;
+    }
+
+    return {
+      providerId: "anthropic",
+      status: "healthy",
+      latencyMs,
+      error: null,
+      checkedAt,
+    } satisfies AIProviderHealth;
+  } catch (error) {
+    const latencyMs = Date.now() - start;
+    return {
+      providerId: "anthropic",
+      status: "unavailable",
+      latencyMs,
+      error: {
+        message: error instanceof Error ? error.message : "Anthropic health check failed",
+      },
+      checkedAt,
+    } satisfies AIProviderHealth;
+  }
+}

--- a/lib/ai/providers/ollama.ts
+++ b/lib/ai/providers/ollama.ts
@@ -1,0 +1,205 @@
+import type {
+  AIChatStreamRequest,
+  AIChatStreamResult,
+  AIChatUsage,
+  AIEmbeddingRequest,
+  AIEmbeddingResponse,
+  AIProviderHealth,
+} from "@/lib/ai/types";
+import { env } from "@/lib/env-validation";
+
+export class OllamaConfigurationError extends Error {
+  constructor() {
+    super("OLLAMA_URL is not configured. Update your environment before requesting a response.");
+    this.name = "OllamaConfigurationError";
+  }
+}
+
+type OllamaChatMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
+
+type OllamaStreamChunk = {
+  message?: {
+    role?: string;
+    content?: string;
+  };
+  done?: boolean;
+  error?: string;
+  eval_count?: number;
+  prompt_eval_count?: number;
+};
+
+function getBaseUrl(): string {
+  const url = env.OLLAMA_URL?.replace(/\/+$/, "");
+  if (!url) {
+    throw new OllamaConfigurationError();
+  }
+  return url;
+}
+
+function toOllamaUsage(chunk?: OllamaStreamChunk): AIChatUsage | undefined {
+  if (!chunk) return undefined;
+  const promptTokens = chunk.prompt_eval_count;
+  const completionTokens = chunk.eval_count;
+  if (typeof promptTokens !== "number" && typeof completionTokens !== "number") {
+    return undefined;
+  }
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens:
+      typeof promptTokens === "number" || typeof completionTokens === "number"
+        ? (promptTokens ?? 0) + (completionTokens ?? 0)
+        : undefined,
+  } satisfies AIChatUsage;
+}
+
+export async function createOllamaChatStream(options: AIChatStreamRequest): Promise<AIChatStreamResult> {
+  const baseUrl = getBaseUrl();
+  const controller = new AbortController();
+  if (options.signal) {
+    options.signal.addEventListener("abort", () => controller.abort(options.signal?.reason));
+  }
+
+  const response = await fetch(`${baseUrl}/api/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: options.model,
+      messages: options.messages.map((message) => ({
+        role: message.role,
+        content: message.content,
+      }) satisfies OllamaChatMessage),
+      stream: true,
+      options: {
+        temperature: options.temperature,
+      },
+    }),
+    signal: controller.signal,
+  });
+
+  if (!response.ok || !response.body) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(`Ollama request failed with status ${response.status}: ${detail}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let resolveUsage: (usage: AIChatUsage | undefined) => void = () => undefined;
+  let rejectUsage: (error: unknown) => void = () => undefined;
+  const usagePromise = new Promise<AIChatUsage | undefined>((resolve, reject) => {
+    resolveUsage = resolve;
+    rejectUsage = reject;
+  });
+
+  const stream = (async function* ollamaStreamGenerator() {
+    let buffer = "";
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let newlineIndex = buffer.indexOf("\n");
+        while (newlineIndex !== -1) {
+          const line = buffer.slice(0, newlineIndex).trim();
+          buffer = buffer.slice(newlineIndex + 1);
+          newlineIndex = buffer.indexOf("\n");
+
+          if (!line) {
+            continue;
+          }
+
+          let parsed: OllamaStreamChunk;
+          try {
+            parsed = JSON.parse(line) as OllamaStreamChunk;
+          } catch (error) {
+            console.warn("Failed to parse Ollama payload", error);
+            continue;
+          }
+
+          if (parsed.error) {
+            const error = new Error(parsed.error || "Ollama streaming error");
+            rejectUsage(error);
+            throw error;
+          }
+
+          const text = parsed.message?.content;
+          if (typeof text === "string" && text.length > 0) {
+            yield text;
+          }
+
+          if (parsed.done) {
+            resolveUsage(toOllamaUsage(parsed));
+          }
+        }
+      }
+
+      resolveUsage(undefined);
+    } catch (error) {
+      rejectUsage(error);
+      throw error;
+    } finally {
+      await reader.cancel().catch(() => undefined);
+    }
+  })();
+
+  return {
+    stream,
+    usage: () => usagePromise,
+  } satisfies AIChatStreamResult;
+}
+
+export async function createOllamaEmbedding(
+  _request: AIEmbeddingRequest,
+): Promise<AIEmbeddingResponse> {
+  throw new Error("Ollama embeddings are not yet supported. Implement once upstream support is available.");
+}
+
+export async function checkOllamaHealth(signal?: AbortSignal): Promise<AIProviderHealth> {
+  const checkedAt = Date.now();
+
+  try {
+    const baseUrl = getBaseUrl();
+    const start = Date.now();
+    const response = await fetch(`${baseUrl}/api/tags`, { signal });
+    const latencyMs = Date.now() - start;
+
+    if (!response.ok) {
+      return {
+        providerId: "ollama",
+        status: "degraded",
+        latencyMs,
+        error: {
+          message: `Ollama health check failed with status ${response.status}`,
+          code: String(response.status),
+        },
+        checkedAt,
+      } satisfies AIProviderHealth;
+    }
+
+    return {
+      providerId: "ollama",
+      status: "healthy",
+      latencyMs,
+      error: null,
+      checkedAt,
+    } satisfies AIProviderHealth;
+  } catch (error) {
+    const missingUrl = error instanceof OllamaConfigurationError || !env.OLLAMA_URL;
+    return {
+      providerId: "ollama",
+      status: "unavailable",
+      error: {
+        message: error instanceof Error ? error.message : "Ollama health check failed",
+        code: missingUrl ? "missing_url" : undefined,
+      },
+      checkedAt,
+    } satisfies AIProviderHealth;
+  }
+}

--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -1,3 +1,82 @@
+export type AIChatMessageRole = "system" | "user" | "assistant";
+
+export interface AIChatMessage {
+  role: AIChatMessageRole;
+  content: string;
+}
+
+export interface AIChatUsage {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+}
+
+export interface AIChatRequestBase {
+  messages: AIChatMessage[];
+  model: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+  topP?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AIChatStreamRequest extends AIChatRequestBase {
+  signal?: AbortSignal;
+}
+
+export interface AIChatStreamResult {
+  stream: AsyncGenerator<string, void, unknown>;
+  usage: () => Promise<AIChatUsage | undefined>;
+}
+
+export interface AIEmbeddingRequest {
+  model: string;
+  input: string | string[];
+  signal?: AbortSignal;
+}
+
+export interface AIEmbeddingResponse {
+  embeddings: number[][];
+  dimensions?: number;
+  model?: string;
+  usage?: {
+    promptTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+export type AIProviderStatus = "healthy" | "degraded" | "unavailable";
+
+export interface AIProviderHealth {
+  providerId: string;
+  status: AIProviderStatus;
+  latencyMs?: number;
+  error?: {
+    message: string;
+    code?: string;
+    details?: unknown;
+  } | null;
+  checkedAt: number;
+}
+
+export interface AIChatProvider {
+  id: string;
+  displayName: string;
+  priority: number;
+  weight?: number;
+  createChatStream: (options: AIChatStreamRequest) => Promise<AIChatStreamResult>;
+  checkHealth: (signal?: AbortSignal) => Promise<AIProviderHealth>;
+}
+
+export interface AIEmbeddingProvider {
+  id: string;
+  displayName: string;
+  priority: number;
+  weight?: number;
+  createEmbedding: (request: AIEmbeddingRequest) => Promise<AIEmbeddingResponse>;
+  checkHealth: (signal?: AbortSignal) => Promise<AIProviderHealth>;
+}
+
 export interface CoachCitation {
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
- add shared AI request, usage, and health contracts plus provider registry with health caching and analytics hooks
- implement Anthropic, Together, Ollama, and expanded OpenAI clients that follow the unified streaming and health interfaces
- document provider abstraction architecture, configuration requirements, and outstanding TODOs

## Testing
- npm run typecheck *(fails: pre-existing JSX syntax errors in app/(dashboard)/help/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d8722cf5f08326960313665f82b2ef