### PR TITLE
Add AI provider telemetry instrumentation and health tests

### DIFF
--- a/__tests__/health-endpoint.test.ts
+++ b/__tests__/health-endpoint.test.ts
@@ -1,0 +1,223 @@
+const loggerInfo = jest.fn();
+const loggerWarn = jest.fn();
+const loggerError = jest.fn();
+
+type MockLogger = {
+  requestId: string;
+  info: jest.Mock;
+  warn: jest.Mock;
+  error: jest.Mock;
+  child: jest.Mock;
+  withUser: jest.Mock;
+};
+
+const mockLogger: MockLogger = {
+  requestId: "req-test",
+  info: loggerInfo,
+  warn: loggerWarn,
+  error: loggerError,
+  child: jest.fn(),
+  withUser: jest.fn(),
+};
+
+mockLogger.child.mockReturnValue(mockLogger);
+mockLogger.withUser.mockReturnValue(mockLogger);
+
+jest.mock("../lib/logging/logger", () => ({
+  createRequestLogger: jest.fn(() => mockLogger),
+}));
+
+const mockSuccess = jest.fn((payload: unknown, init?: unknown) => ({ payload, init }));
+const mockError = jest.fn();
+
+jest.mock("../app/api/_lib/response", () => ({
+  success: mockSuccess,
+  error: mockError,
+}));
+
+jest.mock("../lib/analytics/server", () => ({
+  serverAnalytics: { capture: jest.fn(), isEnabled: true },
+}));
+
+jest.mock("../lib/env-validation", () => ({
+  env: {
+    OPENAI_API_KEY: "sk-openai",
+    ANTHROPIC_API_KEY: "sk-anthropic",
+    TOGETHER_API_KEY: undefined,
+    OLLAMA_URL: null,
+  },
+}));
+
+const selectMock = jest.fn(() => ({
+  limit: jest.fn().mockResolvedValue({ data: [], error: null }),
+}));
+const fromMock = jest.fn(() => ({ select: selectMock }));
+
+jest.mock("../lib/supabase/service-role-client", () => ({
+  getSupabaseServiceRoleClient: jest.fn(() => ({
+    from: fromMock,
+  })),
+}));
+
+jest.mock("../lib/ai/provider-registry", () => ({
+  getChatProviderDiagnostics: jest.fn(() => ({
+    providers: {
+      openai: {
+        status: "healthy",
+        checkedAt: 1700000000000,
+        latencyMs: 50,
+        error: null,
+        successCount: 4,
+        failureCount: 1,
+        lastSuccessAt: 1699990000000,
+        lastFailureAt: 1699980000000,
+      },
+      anthropic: {
+        status: "degraded",
+        checkedAt: 1700001000000,
+        latencyMs: 120,
+        error: { message: "rate limited" },
+        successCount: 1,
+        failureCount: 2,
+        lastSuccessAt: 1699995000000,
+        lastFailureAt: 1699996000000,
+      },
+    },
+    lastSelected: {
+      providerId: "openai",
+      status: "healthy",
+      fallbackUsed: false,
+      selectedAt: 1700002000000,
+    },
+  })),
+  getProviderStatistics: jest.fn(() => [
+    {
+      providerId: "openai",
+      status: "healthy",
+      successes: 4,
+      failures: 1,
+      degraded: 0,
+      lastLatencyMs: 48,
+      lastCheckedAt: 1700000000000,
+    },
+    {
+      providerId: "anthropic",
+      status: "degraded",
+      successes: 1,
+      failures: 2,
+      degraded: 3,
+      lastLatencyMs: 120,
+      lastCheckedAt: 1700001000000,
+    },
+    {
+      providerId: "ollama",
+      status: "unavailable",
+      successes: 0,
+      failures: 5,
+      degraded: 0,
+      lastLatencyMs: null,
+      lastCheckedAt: 1700001500000,
+    },
+  ]),
+}));
+
+describe("/api/health", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns provider telemetry snapshot", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2023-11-14T22:13:20Z"));
+    const { GET } = await import("../app/api/health/route");
+
+    const response = await GET({} as Request);
+
+    expect(mockError).not.toHaveBeenCalled();
+    expect(mockSuccess).toHaveBeenCalledTimes(1);
+
+    const [payload, init] = mockSuccess.mock.calls[0];
+    expect(init).toMatchObject({ requestId: "req-test" });
+    expect(payload).toMatchInlineSnapshot(`
+      {
+        "dependencies": {
+          "aiProviders": {
+            "configuration": {
+              "anthropic": "configured",
+              "ollama": "missing",
+              "openai": "configured",
+              "together": "missing",
+            },
+            "selection": {
+              "fallbackUsed": false,
+              "providerId": "openai",
+              "providerStatus": "healthy",
+              "selectedAt": "2023-11-14T22:46:40.000Z",
+            },
+            "stats": {
+              "anthropic": {
+                "degradedCount": 3,
+                "error": {
+                  "message": "rate limited",
+                },
+                "failureCount": 2,
+                "lastCheckedAt": "2023-11-14T22:30:00.000Z",
+                "lastFailureAt": "2023-11-14T21:06:40.000Z",
+                "lastSuccessAt": "2023-11-14T20:50:00.000Z",
+                "latencyMs": 120,
+                "status": "degraded",
+                "successCount": 1,
+              },
+              "ollama": {
+                "degradedCount": 0,
+                "error": null,
+                "failureCount": 5,
+                "lastCheckedAt": "2023-11-14T22:38:20.000Z",
+                "lastFailureAt": null,
+                "lastSuccessAt": null,
+                "latencyMs": null,
+                "status": "unavailable",
+                "successCount": 0,
+              },
+              "openai": {
+                "degradedCount": 0,
+                "error": null,
+                "failureCount": 1,
+                "lastCheckedAt": "2023-11-14T22:13:20.000Z",
+                "lastFailureAt": "2023-11-14T16:40:00.000Z",
+                "lastSuccessAt": "2023-11-14T19:26:40.000Z",
+                "latencyMs": 48,
+                "status": "healthy",
+                "successCount": 4,
+              },
+            },
+          },
+          "analytics": {
+            "status": "ok",
+          },
+          "supabase": {
+            "latencyMs": 0,
+            "message": null,
+            "status": "ok",
+          },
+        },
+        "status": "ok",
+        "timestamp": "2023-11-14T22:13:20.000Z",
+      }
+    `);
+
+    expect(loggerInfo).toHaveBeenCalled();
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "Provider health degraded",
+      expect.objectContaining({ providerId: "anthropic" }),
+    );
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "Provider health degraded",
+      expect.objectContaining({ providerId: "ollama" }),
+    );
+    expect(response).toEqual({ payload, init });
+  });
+});

--- a/__tests__/provider-registry.test.ts
+++ b/__tests__/provider-registry.test.ts
@@ -1,0 +1,113 @@
+import type { ProviderStatistics } from "../lib/ai/provider-registry";
+
+const analyticsCapture = jest.fn();
+const openaiHealthMock = jest.fn();
+const anthropicHealthMock = jest.fn();
+const togetherHealthMock = jest.fn();
+const ollamaHealthMock = jest.fn();
+
+jest.mock("../lib/analytics/server", () => ({
+  serverAnalytics: {
+    capture: analyticsCapture,
+    isEnabled: true,
+  },
+}));
+
+jest.mock("../lib/ai/providers/openai", () => ({
+  createOpenAIChatStream: jest.fn(),
+  checkOpenAIHealth: openaiHealthMock,
+  createOpenAIEmbedding: jest.fn(),
+}));
+
+jest.mock("../lib/ai/providers/anthropic", () => ({
+  createAnthropicChatStream: jest.fn(),
+  checkAnthropicHealth: anthropicHealthMock,
+}));
+
+jest.mock("../lib/ai/providers/together", () => ({
+  createTogetherChatStream: jest.fn(),
+  createTogetherEmbedding: jest.fn(),
+  checkTogetherHealth: togetherHealthMock,
+}));
+
+jest.mock("../lib/ai/providers/ollama", () => ({
+  createOllamaChatStream: jest.fn(),
+  checkOllamaHealth: ollamaHealthMock,
+}));
+
+describe("provider registry telemetry", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("caches health checks and aggregates provider statistics", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2024-01-01T00:00:00Z"));
+    jest.resetModules();
+
+    openaiHealthMock.mockReset().mockImplementation(async () => ({
+      providerId: "openai",
+      status: "healthy" as const,
+      latencyMs: 45,
+      checkedAt: Date.now(),
+    }));
+    anthropicHealthMock.mockReset().mockImplementation(async () => ({
+      providerId: "anthropic",
+      status: "degraded" as const,
+      latencyMs: 120,
+      checkedAt: Date.now(),
+    }));
+    togetherHealthMock.mockReset().mockImplementation(async () => ({
+      providerId: "together",
+      status: "healthy" as const,
+      latencyMs: 90,
+      checkedAt: Date.now(),
+    }));
+    ollamaHealthMock.mockReset().mockImplementation(async () => ({
+      providerId: "ollama",
+      status: "unavailable" as const,
+      latencyMs: 200,
+      checkedAt: Date.now(),
+      error: { message: "offline" },
+    }));
+
+    const registry = await import("../lib/ai/provider-registry");
+
+    await registry.getActiveChatProvider();
+    expect(openaiHealthMock).toHaveBeenCalledTimes(1);
+
+    await registry.getActiveChatProvider();
+    expect(openaiHealthMock).toHaveBeenCalledTimes(1);
+
+    await registry.getProviderHealth("anthropic");
+    await registry.getProviderHealth("ollama");
+
+    registry.recordProviderSuccess("openai", { latencyMs: 55 });
+    registry.recordProviderFailure("openai", new Error("boom"));
+    registry.recordProviderFailure("ollama", new Error("offline"));
+
+    const stats = registry.getProviderStatistics();
+    const indexById = Object.fromEntries(stats.map((item: ProviderStatistics) => [item.providerId, item]));
+
+    expect(indexById.openai).toMatchObject({
+      status: "healthy",
+      successes: 1,
+      failures: 1,
+      degraded: 0,
+      lastLatencyMs: 55,
+    });
+
+    expect(indexById.anthropic).toMatchObject({
+      status: "degraded",
+      degraded: 1,
+    });
+
+    expect(indexById.ollama).toMatchObject({
+      status: "unavailable",
+      failures: 2,
+    });
+
+    expect(indexById.together.status).toBe("unknown");
+  });
+});

--- a/docs/analytics/posthog-dashboards.md
+++ b/docs/analytics/posthog-dashboards.md
@@ -1,0 +1,67 @@
+# PostHog Dashboard Seeds
+
+This document outlines the core telemetry events captured by the AI orchestration layer and suggests dashboard widgets that help monitor provider behaviour, latency, and failover patterns.
+
+## Core Events
+
+### `i_chat_completed`
+- **When**: Emitted after a coach session streaming request successfully finalises.
+- **Key properties**:
+  - `providerId` – identifier of the selected chat provider.
+  - `providerStatus` – health status (`healthy` or `degraded`) at the time of selection.
+  - `failoverCount` – number of fallback attempts before the final provider responded.
+  - `degradedMode` – boolean flag showing whether a degraded provider handled the request.
+  - `latencyMs` – total request latency from submission to completion.
+  - `tokensPrompt`, `tokensCompletion`, `tokensTotal` – token counts (null-safe).
+  - `fallbackUsed`, `attempts` – metadata describing the evaluation pipeline.
+  - `knowledgeChunks`, `historyTurns` – contextual payload sizes for correlation.
+
+### `i_request_failed`
+- **When**: Emitted whenever a provider stream fails to initialise or errors mid-stream.
+- **Key properties**:
+  - `providerId` – provider that raised the error.
+  - `durationMs` – elapsed time before the failure surfaced.
+  - `errorCode` and `message` – sanitized diagnostic information.
+  - Additional metadata passed by the orchestrator (e.g., failure stage, fallback usage).
+
+### `i_provider_health_changed`
+- **When**: Triggered when a provider’s health state transitions (healthy ↔ degraded/unavailable).
+- **Key properties**:
+  - `providerId`
+  - `previousStatus` / `currentStatus`
+  - `latencyMs` and `checkedAt` from the last health probe.
+  - `errorMessage` / `errorCode` if supplied by the health check.
+
+### Suggested auxiliary events
+- `i_provider_health_snapshot` (optional) – batch capture of `getProviderStatistics()` output if periodic snapshots are required for long-term trending.
+
+## Dashboard Blueprint
+
+1. **Provider Latency Histogram**
+   - Chart `latencyMs` from `i_chat_completed`.
+   - Segment by `providerId` and `degradedMode` to spot regressions.
+
+2. **Provider Selection Pie Chart**
+   - Use `i_chat_completed` events.
+   - Slice by `providerId` to understand distribution of routing decisions.
+   - Add a secondary view grouped by `fallbackUsed` to monitor failover pressure.
+
+3. **Failover Timeline**
+   - Line chart over time using `failoverCount` aggregated daily.
+   - Combine with `i_request_failed` counts to correlate spikes.
+
+4. **Health Status Table**
+   - Feed from `i_provider_health_changed` (and optional snapshot events).
+   - Display current `status`, `successes`, `failures`, `degraded` counters, and `lastLatencyMs` from `getProviderStatistics()`.
+
+5. **Error Drill-down**
+   - Utilize `i_request_failed`.
+   - Break down by `errorCode` and `providerId` to quickly identify systemic outages.
+
+## Feature Flags & Environment Dependencies
+
+- **PostHog ingestion** – requires `POSTHOG_PROJECT_API_KEY` and `POSTHOG_HOST` to be configured in the environment. The analytics client no-ops when disabled.
+- **Provider credentials** – `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `TOGETHER_API_KEY`, and `OLLAMA_URL` affect which providers surface in telemetry. Missing credentials will appear as `missing` in `/api/health`.
+- **Degraded-mode routing** – ensure any feature flag controlling provider priority weights is documented alongside the dashboards if custom routing toggles exist.
+
+Use this document as a seed when creating or updating PostHog dashboards so that observability improvements remain consistent across environments.

--- a/lib/ai/orchestrator.ts
+++ b/lib/ai/orchestrator.ts
@@ -351,7 +351,7 @@ export async function createCoachStream(options: CoachStreamOptions): Promise<Co
 
         if (!outcomeRecorded) {
           outcomeRecorded = true;
-          recordProviderSuccess(providerId);
+          recordProviderSuccess(providerId, { latencyMs });
         }
 
         const analyticsProperties = {
@@ -359,6 +359,8 @@ export async function createCoachStream(options: CoachStreamOptions): Promise<Co
           providerStatus,
           personaId: options.personaId,
           fallbackUsed,
+          degradedMode: providerStatus === "degraded",
+          failoverCount: Math.max(0, attemptSummaries.length - 1),
           latencyMs,
           startedAt: new Date(requestStartedAt).toISOString(),
           completedAt: new Date(completedAt).toISOString(),


### PR DESCRIPTION
## Summary
- expand the provider registry with degraded/failure counters, latency tracking, and a `getProviderStatistics` helper used by analytics
- enrich the coach orchestrator event payload and the `/api/health` route with provider telemetry logging and statistics exposure
- document PostHog dashboard seeds and add Jest coverage for registry health caching plus the health endpoint payload

## Testing
- npm run lint
- npm run typecheck
- npm run test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d8a4800d208326bc985306e3dce1d1