### PR TITLE
Bootstrap Playwright e2e suite with seeded fixtures

### DIFF
--- a/docs/build-plan/tasks/summary-2025-09-27.md
+++ b/docs/build-plan/tasks/summary-2025-09-27.md
@@ -10,6 +10,7 @@
 - Added Jest smoke tests for logging helpers and coach prompt builder, verifying core scaffolding continues to compile.
 - Authored docker-compose profiles for the Next.js app (with optional Ollama) and wrote local onboarding instructions.
 - Configured Jest to load env defaults and cleanup helpers, preparing groundwork for broader unit coverage.
+- Bootstrapped a Playwright e2e suite with deterministic Supabase fixtures covering auth gates, the Today dashboard, and Marcus coach streaming.
 ## Task Status Changes
 - project-foundations-and-environment/tasks.md: Phase 3 Step 2 marked **Complete** after publishing the audit.
 - data-and-backend-infrastructure/tasks.md: Phase 1 Steps 1-3 now **Complete**; Phase 2 Step 3 and Phase 3 Step 1 remain **Complete** with new seed script and middleware docs; index/policy backlog still **Started**.
@@ -20,3 +21,9 @@
 - Roll the new logger through remaining API routes and pipe AI-provider status into the health endpoint once the registry lands.
 - Capture AI usage metrics (latency, token counts, retrieval stats) and pipe them into PostHog or the future observability sink.
 - Begin designing the AI provider abstraction once logging/metrics plumbing proves stable.
+- Document Supabase-powered prerequisites and expand the Playwright suite with onboarding and reflections flows once the baseline stabilizes.
+
+## E2E Testing Instructions
+- Start the Supabase local stack (`npx supabase start`) and apply schema/seed data (`npx supabase db push` then `psql "$SUPABASE_DB_URL" -f supabase/seed.sql`).
+- Export the Supabase anon and service role keys to your shell so Playwright can seed fixtures.
+- Run the application server and tests with `npm run e2e -- --workers=1 --reporter=line` (the config defaults to `npm run dev` via Playwright's web server integration).

--- a/docs/build-plan/tasks/testing-and-quality-assurance/tasks.md
+++ b/docs/build-plan/tasks/testing-and-quality-assurance/tasks.md
@@ -2,7 +2,7 @@
 
 ## Phase 1: Automated Testing Foundations
 1. [Started] Configure Jest for unit and integration coverage across stores, hooks, API routes, and AI modules, including module mocks and shared fixtures.
-2. Stand up Playwright end-to-end suites covering auth, onboarding, habit logging, reflections, coach chat, and offline scenarios; define test data management strategy.
+2. [Started] Stand up Playwright end-to-end suites covering auth, onboarding, habit logging, reflections, coach chat, and offline scenarios; initial `auth`, `dashboard`, and `coach` specs now run against deterministic Supabase fixtures seeded in Playwright global setup.
 3. Establish reusable testing utilities (factories, Supabase seeders, mock AI providers) to streamline scenario creation. [P]
 
 ## Phase 2: AI Evaluation Harness

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,32 @@
+# Playwright End-to-End Tests
+
+The Playwright suite exercises core Pocket Philosopher flows against a running development server and Supabase instance. The fixtures are seeded during Playwright's global setup so that tests remain deterministic across runs.
+
+## Prerequisites
+- Supabase CLI installed locally.
+- Supabase stack running via `npx supabase start`.
+- Database schema applied with `npx supabase db push`.
+- Seed content loaded with `psql "$SUPABASE_DB_URL" -f supabase/seed.sql` (or the Supabase Studio SQL editor).
+- Environment variables exported in the shell that launches Playwright:
+  - `NEXT_PUBLIC_SUPABASE_URL`
+  - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+  - `SUPABASE_SERVICE_ROLE_KEY`
+
+The service role key is required so the global setup can create/update the deterministic e2e user and associated practice fixtures.
+
+## Running the Suite
+1. Ensure `npm install` has been executed.
+2. Start Supabase and the database seeds as described above.
+3. Run the tests with:
+   ```bash
+   npm run e2e -- --workers=1 --reporter=line
+   ```
+
+The Playwright configuration automatically starts the Next.js dev server (`npm run dev`) unless one is already running on `http://127.0.0.1:3000`.
+
+## Seeded User
+The tests authenticate with the seeded user defined in `e2e/utils/test-users.ts`.
+- Email: `e2e.marcus@example.com`
+- Password: `TestingRocks123!`
+
+The global setup ensures this account exists and resets dashboard data (practices, daily progress, Marcus conversations) before the suite runs.

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,167 @@
+import type { FullConfig } from "@playwright/test";
+
+import { getSupabaseServiceRoleClient } from "@/lib/supabase/service-role-client";
+
+import { getTestUser } from "./utils/test-users";
+
+const PRACTICE_FIXTURES = [
+  {
+    name: "Stoic Breathing Reset",
+    description: "Pause for four steady breaths to reset attention.",
+    virtue: "temperance",
+    sort_order: 1,
+  },
+  {
+    name: "Evening Reflection Ledger",
+    description: "Close the day by naming a win and a lesson.",
+    virtue: "wisdom",
+    sort_order: 2,
+  },
+  {
+    name: "Gratitude Capture",
+    description: "Write one note of appreciation for someone who helped today.",
+    virtue: "justice",
+    sort_order: 3,
+  },
+] as const;
+
+async function findUserIdByEmail(admin: ReturnType<typeof getSupabaseServiceRoleClient>, email: string) {
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const { data, error } = await admin.auth.admin.listUsers({ page, perPage });
+
+    if (error) {
+      throw new Error(`Unable to list Supabase users: ${error.message}`);
+    }
+
+    const match = data.users.find((candidate) => candidate.email?.toLowerCase() === email.toLowerCase());
+    if (match) {
+      return match.id;
+    }
+
+    if (!data.nextPage) {
+      return null;
+    }
+
+    page = data.nextPage;
+  }
+}
+
+async function ensureTestUser() {
+  const admin = getSupabaseServiceRoleClient();
+  const user = getTestUser("primary");
+
+  let userId = await findUserIdByEmail(admin, user.email);
+
+  if (!userId) {
+    const { data, error } = await admin.auth.admin.createUser({
+      email: user.email,
+      password: user.password,
+      email_confirm: true,
+    });
+
+    if (error || !data.user) {
+      throw new Error(`Failed to create test user: ${error?.message ?? "unknown error"}`);
+    }
+
+    userId = data.user.id;
+  } else {
+    const { error: updateError } = await admin.auth.admin.updateUserById(userId, {
+      password: user.password,
+      email_confirm: true,
+    });
+
+    if (updateError) {
+      throw new Error(`Failed to update test user credentials: ${updateError.message}`);
+    }
+  }
+
+  return { admin, userId } as const;
+}
+
+async function resetDashboardData(admin: ReturnType<typeof getSupabaseServiceRoleClient>, userId: string) {
+  const today = new Date().toISOString().slice(0, 10);
+
+  const deletions = [
+    admin.from("marcus_messages").delete().eq("user_id", userId),
+    admin.from("marcus_conversations").delete().eq("user_id", userId),
+    admin.from("habit_logs").delete().eq("user_id", userId),
+    admin.from("habits").delete().eq("user_id", userId),
+    admin.from("daily_progress").delete().eq("user_id", userId).neq("date", today),
+  ];
+
+  for (const deletion of deletions) {
+    const { error } = await deletion;
+    if (error) {
+      throw new Error(`Failed to reset seeded data: ${error.message}`);
+    }
+  }
+
+  const { error: profileError } = await admin
+    .from("profiles")
+    .upsert(
+      {
+        user_id: userId,
+        preferred_persona: "marcus",
+        preferred_virtue: "wisdom",
+        onboarding_complete: true,
+        timezone: "UTC",
+      },
+      { onConflict: "user_id" },
+    );
+
+  if (profileError) {
+    throw new Error(`Failed to upsert profile for test user: ${profileError.message}`);
+  }
+
+  const { error: habitsError } = await admin
+    .from("habits")
+    .insert(
+      PRACTICE_FIXTURES.map((practice, index) => ({
+        user_id: userId,
+        name: practice.name,
+        description: practice.description,
+        virtue: practice.virtue,
+        frequency: "daily",
+        sort_order: index + 1,
+      })),
+    );
+
+  if (habitsError) {
+    throw new Error(`Failed to seed practice fixtures: ${habitsError.message}`);
+  }
+
+  const { error: progressError } = await admin
+    .from("daily_progress")
+    .upsert(
+      {
+        user_id: userId,
+        date: today,
+        morning_intention: "Practice deliberate calm and focus.",
+        return_score: 72,
+        streak_days: 4,
+        wisdom_score: 75,
+        justice_score: 68,
+        temperance_score: 70,
+        courage_score: 71,
+      },
+      { onConflict: "user_id,date" },
+    );
+
+  if (progressError) {
+    throw new Error(`Failed to seed daily progress: ${progressError.message}`);
+  }
+}
+
+export default async function globalSetup(_: FullConfig) {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error(
+      "SUPABASE_SERVICE_ROLE_KEY is required for Playwright tests. Start Supabase locally and export the service role key before running the suite.",
+    );
+  }
+
+  const { admin, userId } = await ensureTestUser();
+  await resetDashboardData(admin, userId);
+}

--- a/e2e/specs/auth.spec.ts
+++ b/e2e/specs/auth.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+import { getTestUser } from "../utils/test-users";
+
+const testUser = getTestUser("primary");
+
+test.describe("Auth flows", () => {
+  test("login page renders sign-in form", async ({ page }) => {
+    await page.goto("/login");
+
+    await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+  });
+
+  test("user can sign in with seeded credentials", async ({ page }) => {
+    await page.goto("/login");
+
+    await page.getByLabel("Email").fill(testUser.email);
+    await page.getByLabel("Password").fill(testUser.password);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await page.waitForURL("**/today");
+
+    await expect(page.getByRole("heading", { name: "Daily focus" })).toBeVisible();
+    await expect(page.getByText("Set the tone for the day")).toBeVisible();
+  });
+
+  test("protected routes redirect unauthenticated visitors", async ({ page }) => {
+    await page.goto("/today");
+    await page.waitForURL("**/login");
+    await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+  });
+});

--- a/e2e/specs/coach.spec.ts
+++ b/e2e/specs/coach.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+
+import { signInViaApi } from "../utils/auth";
+
+const MOCK_CONVERSATION_ID = "11111111-2222-3333-4444-555555555555";
+const MOCK_MESSAGE_ID = "99999999-8888-7777-6666-555555555555";
+
+test.describe("Marcus coach", () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    await signInViaApi(page, { baseURL: baseURL ?? undefined });
+  });
+
+  test("streams a mocked coaching response", async ({ page }) => {
+    await page.route("**/api/marcus", async (route, request) => {
+      if (request.method() !== "POST") {
+        await route.fallback();
+        return;
+      }
+
+      const body = [
+        `event: start`,
+        `data: ${JSON.stringify({ conversation_id: MOCK_CONVERSATION_ID, message_id: MOCK_MESSAGE_ID })}`,
+        "",
+        `event: chunk`,
+        `data: ${JSON.stringify({ delta: "Begin with a slow inhale." })}`,
+        "",
+        `event: chunk`,
+        `data: ${JSON.stringify({ delta: " Exhale tension and return to the present." })}`,
+        "",
+        `event: complete`,
+        `data: ${JSON.stringify({ tokens: 42 })}`,
+        "",
+      ].join("\n");
+
+      await route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+        body,
+      });
+    });
+
+    await page.goto("/marcus");
+
+    await expect(page.getByRole("heading", { name: /Choose your guide/ })).toBeVisible();
+
+    const composer = page.getByPlaceholder("Ask a question or share a reflection…");
+    await composer.fill("How can I stay present during a busy day?");
+    await page.getByRole("button", { name: "Send" }).click();
+
+    await expect(page.getByText("How can I stay present during a busy day?", { exact: false })).toBeVisible();
+    await expect(
+      page.getByText("Begin with a slow inhale. Exhale tension and return to the present.", { exact: false }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/specs/dashboard.spec.ts
+++ b/e2e/specs/dashboard.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+import { signInViaApi } from "../utils/auth";
+
+test.describe("Dashboard", () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    await signInViaApi(page, { baseURL: baseURL ?? undefined });
+  });
+
+  test("today view renders core widgets", async ({ page }) => {
+    await page.goto("/today");
+
+    await expect(page.getByRole("heading", { name: "Daily focus" })).toBeVisible();
+    await expect(page.getByText("Set the tone for the day")).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Tap practices as you complete them/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Stoic Breathing Reset/ })).toBeVisible();
+  });
+
+  test("completing a practice toggles completion state", async ({ page }) => {
+    await page.goto("/today");
+
+    const practiceButton = page.getByRole("button", { name: /Stoic Breathing Reset/ });
+
+    await expect(practiceButton.locator('svg[data-lucide="circle"]').first()).toBeVisible();
+    await practiceButton.click();
+    await expect(practiceButton.locator('svg[data-lucide="check-circle-2"]').first()).toBeVisible();
+  });
+});

--- a/e2e/utils/auth.ts
+++ b/e2e/utils/auth.ts
@@ -1,0 +1,50 @@
+import { request, type Page, type BrowserContext } from "@playwright/test";
+
+import { getTestUser } from "./test-users";
+
+function resolveBaseURL(baseURL?: string) {
+  if (baseURL) return baseURL;
+  if (process.env.PLAYWRIGHT_BASE_URL) return process.env.PLAYWRIGHT_BASE_URL;
+  return "http://127.0.0.1:3000";
+}
+
+export async function signInViaApi(page: Page, options?: { baseURL?: string }) {
+  const targetBaseURL = resolveBaseURL(options?.baseURL);
+  const user = getTestUser("primary");
+
+  const requestContext = await request.newContext({
+    baseURL: targetBaseURL,
+    extraHTTPHeaders: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  const response = await requestContext.post("/api/auth", {
+    data: {
+      action: "signIn",
+      email: user.email,
+      password: user.password,
+    },
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    await requestContext.dispose();
+    throw new Error(`Failed to authenticate test user. Status: ${response.status()} Body: ${body}`);
+  }
+
+  const storageState = await requestContext.storageState();
+  await requestContext.dispose();
+
+  const url = new URL(targetBaseURL);
+
+  type CookieParam = Parameters<BrowserContext["addCookies"]>[0][number];
+
+  const cookies: CookieParam[] = storageState.cookies.map((cookie) => ({
+    ...cookie,
+    domain: cookie.domain ?? url.hostname,
+    path: cookie.path ?? "/",
+  }));
+
+  await page.context().addCookies(cookies);
+}

--- a/e2e/utils/test-users.ts
+++ b/e2e/utils/test-users.ts
@@ -1,0 +1,13 @@
+export type TestUserKey = keyof typeof testUsers;
+
+export const testUsers = {
+  primary: {
+    email: "e2e.marcus@example.com",
+    password: "TestingRocks123!",
+    displayName: "E2E Marcus",
+  },
+} as const;
+
+export function getTestUser(key: TestUserKey = "primary") {
+  return testUsers[key];
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,38 +1,32 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000";
+
 export default defineConfig({
-  testDir: "./e2e",
-  fullyParallel: true,
+  testDir: "./e2e/specs",
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  timeout: 30_000,
+  globalSetup: "./e2e/global-setup.ts",
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000",
+    baseURL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
+    actionTimeout: 15_000,
+    navigationTimeout: 15_000,
   },
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
-    {
-      name: "mobile",
-      use: { ...devices["Pixel 7"] },
+      use: { ...devices["Desktop Chrome"], baseURL },
     },
   ],
   webServer: {
     command: "npm run dev",
-    port: 3000,
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
   },


### PR DESCRIPTION
## Summary
- configure Playwright to use e2e/specs with a single worker, base URL env support, and Supabase-seeding global setup
- add deterministic auth, dashboard, and coach Playwright specs with API sign-in helper and test user fixtures
- document e2e prerequisites/run steps and update the build-plan testing status to reflect new coverage

## Testing
- npm run lint
- npm run typecheck
- npm run e2e -- --workers=1 --reporter=line --pass-with-no-tests *(fails: Supabase service not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d965e177e4832685ef8e45df5e78e9