### PR TITLE
refactor: split jest projects for client and server

### DIFF
--- a/components/ui/__tests__/button.test.tsx
+++ b/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+
+import { Button } from "../button";
+
+describe("Button", () => {
+  it("renders the provided label", () => {
+    render(<Button>Click me</Button>);
+
+    expect(screen.getByRole("button", { name: "Click me" })).toBeInTheDocument();
+  });
+});

--- a/docs/build-plan/tasks/summary-2025-09-27.md
+++ b/docs/build-plan/tasks/summary-2025-09-27.md
@@ -11,13 +11,14 @@
 - Configured Jest to load env defaults and cleanup helpers, preparing groundwork for broader unit coverage.
 - Bootstrapped a Playwright e2e suite with deterministic Supabase fixtures covering auth gates, the Today dashboard, and Marcus coach streaming.
 - Added Jest unit tests for API response helpers and analytics normalization to deepen the foundations.
+- Split Jest into client (jsdom) and server (node) projects with shared environment shims and PostHog shutdown hooks so server suites exit without lingering handles.
 ## Task Status Changes
 - project-foundations-and-environment/tasks.md: Phase 3 Step 2 marked **Complete** after publishing the audit.
 - data-and-backend-infrastructure/tasks.md: Phase 1 Steps 1-3 now **Complete**; Phase 2 Step 3 and Phase 3 Step 1 remain **Complete** with new seed script and middleware docs; index/policy backlog still **Started**.
 - analytics-observability-and-security/tasks.md: Phase 1 Step 1 note updated to reflect backend event tracking progress; Phase 1 Step 3 marked **Complete** with logging helper + health diagnostics.
 
 ## Next Focus
-- Triage the Jest configuration so server-focused suites (e.g., analytics/server helpers) run in a Node environment without leaking `MessagePort` handles from the jsdom/react-testing-library setup.
+- Expand server-side coverage by migrating remaining helper suites into the Node-focused Jest project and monitor for additional teardown needs.
 - Roll the new logger through remaining API routes and pipe AI-provider status into the health endpoint once the registry lands.
 - Capture AI usage metrics (latency, token counts, retrieval stats) and pipe them into PostHog or the future observability sink.
 - Begin designing the AI provider abstraction once logging/metrics plumbing proves stable.

--- a/docs/build-plan/tasks/testing-and-quality-assurance/tasks.md
+++ b/docs/build-plan/tasks/testing-and-quality-assurance/tasks.md
@@ -1,7 +1,7 @@
 # Testing & Quality Assurance — Task Plan
 
 ## Phase 1: Automated Testing Foundations
-1. [Started] Configure Jest for unit and integration coverage across stores, hooks, API routes, and AI modules, including module mocks and shared fixtures.
+1. [Complete] Configure Jest for unit and integration coverage across stores, hooks, API routes, and AI modules, including module mocks and shared fixtures. Client-side suites now run under a dedicated jsdom project while Node-oriented helpers execute in an isolated server project with environment polyfills and teardown helpers so analytics clients shut down cleanly.
 2. [Started] Stand up Playwright end-to-end suites covering auth, onboarding, habit logging, reflections, coach chat, and offline scenarios; initial `auth`, `dashboard`, and `coach` specs now run against deterministic Supabase fixtures seeded in Playwright global setup.
 3. Establish reusable testing utilities (factories, Supabase seeders, mock AI providers) to streamline scenario creation. [P]
 

--- a/jest.setup.env.ts
+++ b/jest.setup.env.ts
@@ -7,51 +7,50 @@ if (!globalThis.TextDecoder) {
   globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { ReadableStream, TransformStream, WritableStream } = require("stream/web");
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { MessageChannel, MessagePort } = require("worker_threads");
+if (!globalThis.ReadableStream || !globalThis.TransformStream || !globalThis.WritableStream) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ReadableStream, TransformStream, WritableStream } = require("stream/web");
 
-if (!globalThis.ReadableStream) {
-  globalThis.ReadableStream = ReadableStream as typeof globalThis.ReadableStream;
-}
-if (!globalThis.TransformStream) {
-  globalThis.TransformStream = TransformStream as typeof globalThis.TransformStream;
-}
-if (!globalThis.WritableStream) {
-  globalThis.WritableStream = WritableStream as typeof globalThis.WritableStream;
-}
-if (!globalThis.MessageChannel) {
-  globalThis.MessageChannel = MessageChannel as typeof globalThis.MessageChannel;
-}
-if (!globalThis.MessagePort) {
-  globalThis.MessagePort = MessagePort as typeof globalThis.MessagePort;
+  if (!globalThis.ReadableStream) {
+    globalThis.ReadableStream = ReadableStream as typeof globalThis.ReadableStream;
+  }
+  if (!globalThis.TransformStream) {
+    globalThis.TransformStream = TransformStream as typeof globalThis.TransformStream;
+  }
+  if (!globalThis.WritableStream) {
+    globalThis.WritableStream = WritableStream as typeof globalThis.WritableStream;
+  }
 }
 
-// Align with Next.js edge primitives so NextResponse works in Jest.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const edgeFetch = require("next/dist/compiled/@edge-runtime/primitives/fetch");
+const ensureEdgeFetch = () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require("next/dist/compiled/@edge-runtime/primitives/fetch");
+};
 
-if (!globalThis.Blob) {
-  globalThis.Blob = edgeFetch.Blob as typeof globalThis.Blob;
-}
-if (!globalThis.File) {
-  globalThis.File = edgeFetch.File as typeof globalThis.File;
-}
-if (!globalThis.FormData) {
-  globalThis.FormData = edgeFetch.FormData as typeof globalThis.FormData;
-}
-if (!globalThis.Headers) {
-  globalThis.Headers = edgeFetch.Headers as typeof globalThis.Headers;
-}
-if (!globalThis.Request) {
-  globalThis.Request = edgeFetch.Request as typeof globalThis.Request;
-}
-if (!globalThis.Response) {
-  globalThis.Response = edgeFetch.Response as typeof globalThis.Response;
-}
-if (!globalThis.fetch) {
-  globalThis.fetch = edgeFetch.fetch as typeof globalThis.fetch;
+if (!globalThis.Blob || !globalThis.File || !globalThis.FormData || !globalThis.Headers || !globalThis.Request || !globalThis.Response || !globalThis.fetch) {
+  const edgeFetch = ensureEdgeFetch();
+
+  if (!globalThis.Blob) {
+    globalThis.Blob = edgeFetch.Blob as typeof globalThis.Blob;
+  }
+  if (!globalThis.File) {
+    globalThis.File = edgeFetch.File as typeof globalThis.File;
+  }
+  if (!globalThis.FormData) {
+    globalThis.FormData = edgeFetch.FormData as typeof globalThis.FormData;
+  }
+  if (!globalThis.Headers) {
+    globalThis.Headers = edgeFetch.Headers as typeof globalThis.Headers;
+  }
+  if (!globalThis.Request) {
+    globalThis.Request = edgeFetch.Request as typeof globalThis.Request;
+  }
+  if (!globalThis.Response) {
+    globalThis.Response = edgeFetch.Response as typeof globalThis.Response;
+  }
+  if (!globalThis.fetch) {
+    globalThis.fetch = edgeFetch.fetch as typeof globalThis.fetch;
+  }
 }
 
 process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "https://example.test";

--- a/jest.setup.server.ts
+++ b/jest.setup.server.ts
@@ -1,0 +1,8 @@
+afterAll(async () => {
+  const analyticsModule = await import("@/lib/analytics/server");
+  const shutdown = analyticsModule.serverAnalytics?.shutdown;
+
+  if (typeof shutdown === "function") {
+    await shutdown.call(analyticsModule.serverAnalytics);
+  }
+});


### PR DESCRIPTION
## Summary
- split the Jest configuration into client (jsdom) and server (node) projects with shared module mapping and a server teardown hook
- scope the shared environment polyfills so Node suites only load the edge fetch shims when required and document the new layout
- add a lightweight RTL button test to exercise the client project and update task docs with the configuration change and follow-up focus

## Testing
- npm test -- __tests__/analytics-server.test.ts __tests__/api-response.test.ts
- npm test -- components/ui/__tests__/button.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da0a57b3bc8326ac54f7b732ef0b85