### PR TITLE
Add service worker provider draft syncing

### DIFF
--- a/components/providers/__tests__/service-worker-provider.test.tsx
+++ b/components/providers/__tests__/service-worker-provider.test.tsx
@@ -1,0 +1,118 @@
+import { act, render } from "@testing-library/react";
+
+import {
+  SERVICE_WORKER_DRAFT_QUEUE_EVENT,
+  SERVICE_WORKER_DRAFT_SYNC_EVENT,
+  ServiceWorkerProvider,
+  type DraftPayload,
+  useServiceWorker,
+} from "../service-worker-provider";
+
+describe("ServiceWorkerProvider", () => {
+  type Listener = (event: { data?: { type?: string; drafts?: DraftPayload[] } }) => void;
+
+  let listeners: Listener[];
+  let controllerPostMessage: jest.Mock;
+
+  beforeEach(() => {
+    listeners = [];
+    controllerPostMessage = jest.fn();
+
+    const serviceWorker = {
+      controller: {
+        postMessage: controllerPostMessage,
+      },
+      addEventListener: jest.fn((event: string, listener: EventListener) => {
+        if (event === "message") {
+          listeners.push(listener as Listener);
+        }
+      }),
+      removeEventListener: jest.fn((event: string, listener: EventListener) => {
+        if (event === "message") {
+          listeners = listeners.filter((registered) => registered !== listener);
+        }
+      }),
+    } as unknown as ServiceWorkerContainer;
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: serviceWorker,
+    });
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - cleaning up test shim
+    delete navigator.serviceWorker;
+  });
+
+  it("exposes recovered drafts when the service worker syncs them", () => {
+    let context: ReturnType<typeof useServiceWorker> | undefined;
+
+    function Consumer() {
+      context = useServiceWorker();
+      return null;
+    }
+
+    render(
+      <ServiceWorkerProvider>
+        <Consumer />
+      </ServiceWorkerProvider>,
+    );
+
+    expect(listeners).toHaveLength(1);
+    expect(context).toBeDefined();
+
+    const syncedDrafts: DraftPayload[] = [
+      { id: "1", table: "practices", payload: { content: "Reflect" } },
+      { id: "2", table: "reflections", payload: { content: "Share" } },
+    ];
+
+    act(() => {
+      listeners.forEach((listener) =>
+        listener({
+          data: { type: SERVICE_WORKER_DRAFT_SYNC_EVENT, drafts: syncedDrafts },
+        }),
+      );
+    });
+
+    expect(context?.pendingDrafts).toEqual(syncedDrafts);
+
+    let consumed: DraftPayload[] = [];
+    act(() => {
+      consumed = context?.consumePendingDrafts() ?? [];
+    });
+
+    expect(consumed).toEqual(syncedDrafts);
+    expect(context?.pendingDrafts).toEqual([]);
+  });
+
+  it("queues drafts for the active service worker controller", () => {
+    let context: ReturnType<typeof useServiceWorker> | undefined;
+
+    function Consumer() {
+      context = useServiceWorker();
+      return null;
+    }
+
+    render(
+      <ServiceWorkerProvider>
+        <Consumer />
+      </ServiceWorkerProvider>,
+    );
+
+    const draft: DraftPayload = {
+      id: "draft-1",
+      table: "practices",
+      payload: { content: "Offline draft" },
+    };
+
+    act(() => {
+      context?.queueDraft(draft);
+    });
+
+    expect(controllerPostMessage).toHaveBeenCalledWith({
+      type: SERVICE_WORKER_DRAFT_QUEUE_EVENT,
+      draft,
+    });
+  });
+});

--- a/components/providers/service-worker-provider.tsx
+++ b/components/providers/service-worker-provider.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export interface DraftPayload {
+  id: string;
+  [key: string]: unknown;
+}
+
+interface DraftSyncMessageEventData {
+  type: typeof SERVICE_WORKER_DRAFT_SYNC_EVENT;
+  drafts?: DraftPayload[];
+}
+
+interface QueueDraftMessageEventData {
+  type: typeof SERVICE_WORKER_DRAFT_QUEUE_EVENT;
+  draft: DraftPayload;
+}
+
+export const SERVICE_WORKER_DRAFT_SYNC_EVENT = "POCKET_PHILOSOPHER_DRAFTS_SYNCED";
+export const SERVICE_WORKER_DRAFT_QUEUE_EVENT = "POCKET_PHILOSOPHER_QUEUE_DRAFT";
+
+export interface ServiceWorkerContextValue {
+  queueDraft: (draft: DraftPayload) => void;
+  pendingDrafts: DraftPayload[];
+  consumePendingDrafts: () => DraftPayload[];
+}
+
+const ServiceWorkerContext = createContext<ServiceWorkerContextValue | null>(null);
+
+const isServiceWorkerSupported = () =>
+  typeof window !== "undefined" && "serviceWorker" in navigator;
+
+export function ServiceWorkerProvider({ children }: { children: ReactNode }) {
+  const [queuedDrafts, setQueuedDrafts] = useState<DraftPayload[]>([]);
+  const [pendingDrafts, setPendingDrafts] = useState<DraftPayload[]>([]);
+
+  const queuedDraftsRef = useRef(queuedDrafts);
+  const pendingDraftsRef = useRef(pendingDrafts);
+
+  useEffect(() => {
+    queuedDraftsRef.current = queuedDrafts;
+  }, [queuedDrafts]);
+
+  useEffect(() => {
+    pendingDraftsRef.current = pendingDrafts;
+  }, [pendingDrafts]);
+
+  const flushQueuedDraftToController = useCallback((draft: DraftPayload) => {
+    if (!isServiceWorkerSupported()) return;
+
+    const controller = navigator.serviceWorker.controller;
+    if (!controller) return;
+
+    const message: QueueDraftMessageEventData = {
+      type: SERVICE_WORKER_DRAFT_QUEUE_EVENT,
+      draft,
+    };
+
+    controller.postMessage(message);
+  }, []);
+
+  const queueDraft = useCallback(
+    (draft: DraftPayload) => {
+      setQueuedDrafts((current) => {
+        const next = [...current, draft];
+        return next;
+      });
+
+      flushQueuedDraftToController(draft);
+    },
+    [flushQueuedDraftToController],
+  );
+
+  const consumePendingDrafts = useCallback(() => {
+    if (!pendingDraftsRef.current.length) {
+      return [];
+    }
+
+    const drafts = [...pendingDraftsRef.current];
+    pendingDraftsRef.current = [];
+    setPendingDrafts([]);
+    return drafts;
+  }, []);
+
+  const registerDraftMessageListener = useCallback(
+    (handler: (drafts: DraftPayload[]) => void) => {
+      if (!isServiceWorkerSupported()) {
+        return () => undefined;
+      }
+
+      const container = navigator.serviceWorker;
+
+      const listener = (event: MessageEvent<DraftSyncMessageEventData>) => {
+        if (event.data?.type !== SERVICE_WORKER_DRAFT_SYNC_EVENT) return;
+
+        const drafts = Array.isArray(event.data.drafts) ? event.data.drafts : [];
+        handler(drafts);
+      };
+
+      container.addEventListener("message", listener);
+
+      return () => {
+        container.removeEventListener("message", listener);
+      };
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const unsubscribe = registerDraftMessageListener((drafts) => {
+      setPendingDrafts(drafts);
+    });
+
+    return unsubscribe;
+  }, [registerDraftMessageListener]);
+
+  useEffect(() => {
+    if (!queuedDraftsRef.current.length) return;
+    setQueuedDrafts([]);
+  }, [pendingDrafts]);
+
+  const value = useMemo<ServiceWorkerContextValue>(
+    () => ({
+      queueDraft,
+      pendingDrafts,
+      consumePendingDrafts,
+    }),
+    [consumePendingDrafts, pendingDrafts, queueDraft],
+  );
+
+  return <ServiceWorkerContext.Provider value={value}>{children}</ServiceWorkerContext.Provider>;
+}
+
+export function useServiceWorker() {
+  const context = useContext(ServiceWorkerContext);
+
+  if (!context) {
+    throw new Error("useServiceWorker must be used within a ServiceWorkerProvider");
+  }
+
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a service worker provider that queues drafts, tracks recovered drafts, and exposes a consumer hook
- ensure recovered drafts are retained until consumers acknowledge them before clearing the local queue
- cover the provider behaviour with dedicated tests for pending drafts and queueing

## Testing
- npm test -- --runTestsByPath components/providers/__tests__/service-worker-provider.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da792372c883269ebf27933455cbb9